### PR TITLE
Develop

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -29,15 +29,16 @@ security:
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
+            
         main:
             lazy: true
             provider: app_user_provider
             custom_authenticator: App\Security\UserAuthenticator
-
+            
             login_throttling:
                 max_attempts: 5
                 interval: '15 minutes'
-
+            
             logout:
                 path: app_logout
                 # where to redirect after logout

--- a/src/Controller/Security/RegistrationController.php
+++ b/src/Controller/Security/RegistrationController.php
@@ -65,7 +65,7 @@ class RegistrationController extends AbstractController
             $this->emailVerifier->sendEmailConfirmation('app_verify_email', $user,
             // here we use the template registration/confirmation_email.html.twig 
                 (new TemplatedEmail())
-                    ->from(new Address('admin@mydomain.fr', 'myStarterPack'))
+                    ->from(new Address('simonchabrier@gmail.com', 'myStarterPack'))
                     ->to($user->getEmail())
                     ->subject('Please Confirm your Email')
                     ->htmlTemplate('registration/confirmation_email.html.twig')
@@ -75,7 +75,7 @@ class RegistrationController extends AbstractController
             //* eg if you need to know new user register personalize this:
             $test_email = (new Email())
             ->from('appMail@Appmail.fr')
-            ->to('myDestinationmail@Appmail.fr')
+            ->to('simonchabrier@gmail.com')
             ->subject('Sujet')
             ->text('Contenu du message que je veux recevoir quand un utilisateur s\'enregistre...');
             $mailer->send($test_email);

--- a/templates/fragments/_modal_login.html.twig
+++ b/templates/fragments/_modal_login.html.twig
@@ -7,7 +7,7 @@
         we are actually not directly on /login #}
 
             <div class="container">
-                <form method="post" action="{{ path('app_login')}}">
+                <form method="post" action="{{ path('app_login')}}" >
                     
                     {% if error is defined and error %}
                         <div class="alert alert-danger">{{ error.messageKey|trans(error.messageData, 'security') }}</div>

--- a/templates/fragments/_navbar.html.twig
+++ b/templates/fragments/_navbar.html.twig
@@ -13,13 +13,22 @@
             User Features
           </a>
           <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
-            <li><a class="dropdown-item" href="{{ path('app_login') }}">Login</a></li>
+            {% if app.user %}
             <li><a class="dropdown-item" href="{{ path('app_logout') }}">LogOut</a></li>
+            {% else %}
+            <li><a class="dropdown-item" href="{{ path('app_login') }}">Login</a></li>
+            {% endif %}
+            {% if app.user %}
+            {% else %}
             <li><hr class="dropdown-divider"></li>
             <li><a class="dropdown-item" href="{{ path('app_register') }}">Register</a></li>
             <li><hr class="dropdown-divider"></li>
-            <li><a class="dropdown-item" href="{{ path('app_forgot_password_request') }}">Reset Password</a></li>
+            {% endif %}
+            {% if app.user %}
             <li><a class="dropdown-item" href="{{ path('app_forgot_password_request') }}">Renew Password</a></li>
+            {% else %}
+            <li><a class="dropdown-item" href="{{ path('app_forgot_password_request') }}">Reset Password</a></li>
+            {% endif %}
           </ul>
         </li>
         {% if app.user %} <!-- IMPORTANT - here, We must hide the login modal window if the user is already logged in so as not to have an error with the csrf token during a password update request if the user is already logged in. -->

--- a/templates/fragments/_navbar.html.twig
+++ b/templates/fragments/_navbar.html.twig
@@ -22,12 +22,14 @@
             <li><a class="dropdown-item" href="{{ path('app_forgot_password_request') }}">Renew Password</a></li>
           </ul>
         </li>
-
+        {% if app.user %} <!-- IMPORTANT - here, We must hide the login modal window if the user is already logged in so as not to have an error with the csrf token during a password update request if the user is already logged in. -->
+            <li class="nav-item"><a class="nav-link" href="{{ path('app_logout') }}">LogOut</a></li>
+        {% else %}
          <li class="nav-item">
             <a class="nav-link" data-toggle="modal" data-target=".Mylogin-modal">Modal Login</a><!-- call modal on : data-target=".login-modal  -->
-            {% include 'fragments/_modal_login.html.twig' %}<!-- include login form fragment inside modal content --> 
+            {% include 'fragments/_modal_login.html.twig' %}<!-- include login form fragment inside modal content -->
         </li>
-                   
+        {% endif %}         
       </ul><!-- nav items end --> 
     </div><!-- nav content end --> 
   </div><!-- container end -->


### PR DESCRIPTION
Fix csrf bug by hide the login modal window if the user is already logged in so as not to have an error with the csrf token during a password update request if the user is already logged in.

Clean header to show only need to see ig user is already logged in or not.